### PR TITLE
fix: Fix wiremock request urls for payments

### DIFF
--- a/mocks/wiremock/mappings/payments/credit-account-payments/paymentReference-statuses.json
+++ b/mocks/wiremock/mappings/payments/credit-account-payments/paymentReference-statuses.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPattern": "/payments/credit-account-payments/([\\w-]*)/statuses"
+    "urlPattern": "/credit-account-payments/([\\w-]*)/statuses"
   },
   "response": {
     "status": 200,

--- a/mocks/wiremock/mappings/payments/payment-groups/paymentGroup-reference.json
+++ b/mocks/wiremock/mappings/payments/payment-groups/paymentGroup-reference.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPattern": "/payments/payment-groups/([\\w-]*)"
+    "urlPattern": "/payment-groups/([\\w-]*)"
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
http://payment-api-aat.service.core-compute-aat.internal/swagger-ui.html?urls.primaryName=payment2#/Payment_group