### PR TITLE
fix: add mapping for new status endpoint

### DIFF
--- a/mocks/wiremock/__files/letterStatus.json
+++ b/mocks/wiremock/__files/letterStatus.json
@@ -1,0 +1,11 @@
+{
+  "additional_data": {},
+  "checksum": "string",
+  "copies": 0,
+  "created_at": "2020-10-13T09:57:53.943Z",
+  "id": "67ff45e6-5a7d-4759-a997-d0ec884e06e5",
+  "message_id": "string",
+  "printed_at": "2020-10-13T09:57:53.943Z",
+  "sent_to_print_at": "2020-10-13T09:57:53.943Z",
+  "status": "Created"
+}

--- a/mocks/wiremock/mappings/sendletter.json
+++ b/mocks/wiremock/mappings/sendletter.json
@@ -22,6 +22,21 @@
         "status": 200,
         "body": "{\"status\": \"UP\"}"
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/letters/67ff45e6-5a7d-4759-a997-d0ec884e06e5",
+        "queryParameters": {
+          "include-additional-info": {
+            "equalTo": "false"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"additional_data\": {}, \"checksum\": \"string\", \"copies\": 0, \"created_at\": \"2020-10-13T09:57:53.943Z\", \"id\": \"67ff45e6-5a7d-4759-a997-d0ec884e06e5\", \"message_id\": \"string\", \"printed_at\": \"2020-10-13T09:57:53.943Z\", \"sent_to_print_at\": \"2020-10-13T09:57:53.943Z\", \"status\": \"Created\"}"
+      }
     }
   ]
 }

--- a/mocks/wiremock/mappings/sendletter.json
+++ b/mocks/wiremock/mappings/sendletter.json
@@ -35,7 +35,7 @@
       },
       "response": {
         "status": 200,
-        "body": "{\"additional_data\": {}, \"checksum\": \"string\", \"copies\": 0, \"created_at\": \"2020-10-13T09:57:53.943Z\", \"id\": \"67ff45e6-5a7d-4759-a997-d0ec884e06e5\", \"message_id\": \"string\", \"printed_at\": \"2020-10-13T09:57:53.943Z\", \"sent_to_print_at\": \"2020-10-13T09:57:53.943Z\", \"status\": \"Created\"}"
+        "bodyFileName": "letterStatus.json"
       }
     }
   ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

FPLA-N/A

### Change description ###

Recent updates to the send letter client means that it now checks the status of the letter after the request has been made.
To account for this the mapping has been updated.

[Swagger docs](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/send-letter-service.json#/send-letter-controller/getLetterStatusUsingGET) for the request

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```