### PR TITLE
fix: .env file not being read

### DIFF
--- a/ccd
+++ b/ccd
@@ -277,6 +277,7 @@ function active_compose_files() {
 }
 
 function create_compose_file_options() {
+    compose_file_options="$compose_file_options --env-file ./.env"
     for compose_file in $(active_compose_files)
     do
             compose_file_options="$compose_file_options -f compose/${compose_file}.yml"


### PR DESCRIPTION
Update the compose file options method so that it specifies the location of the .env file.
In newer versions of docker this resolves the following:
```
WARNING: The DB_USERNAME variable is not set. Defaulting to a blank string.
WARNING: The DB_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The DB_USE_SSL variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_CCD_DEFINITION_STORE variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_CCD_DATA_STORE variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_CCD_GATEWAY variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_CCD_ADMIN variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_CCD_PS variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_FPL_CASE_SERVICE variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_ADOPTION variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_AAC_MANAGE_CASE_ASSIGNMENT variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_XUI_WEBAPP variable is not set. Defaulting to a blank string.
WARNING: The IDAM_KEY_DM_STORE variable is not set. Defaulting to a blank string.
WARNING: The OAUTH2_CLIENT_XUI variable is not set. Defaulting to a blank string.
```
