### PR TITLE
impr: set transaction timeout for definition store api

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -43,6 +43,7 @@ services:
       ELASTIC_SEARCH_ENABLED: "${ES_ENABLED_DOCKER}"
       ELASTIC_SEARCH_HOST: "ccd-elasticsearch"
       ELASTIC_SEARCH_FAIL_ON_IMPORT: "true"
+      DEFINITION_STORE_TX_TIMEOUT_DEFAULT: "${DEF_STORE_TIMEOUT:-30}"
       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
     ports:

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -43,7 +43,7 @@ services:
       ELASTIC_SEARCH_ENABLED: "${ES_ENABLED_DOCKER}"
       ELASTIC_SEARCH_HOST: "ccd-elasticsearch"
       ELASTIC_SEARCH_FAIL_ON_IMPORT: "true"
-      DEFINITION_STORE_TX_TIMEOUT_DEFAULT: "${DEF_STORE_TIMEOUT:-30}"
+      DEFINITION_STORE_TX_TIMEOUT_DEFAULT: "${DEF_STORE_TIMEOUT:-60}"
       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
     ports:


### PR DESCRIPTION
### Change description ###

Added an env variable (`DEFINITION_STORE_TX_TIMEOUT_DEFAULT`) that is used in `ccd-definition-store-api` that allows us to set the transaction timeout.
Added a variable reference to set the above property (`DEF_STORE_TIMEOUT`).

Based off this commit: https://github.com/hmcts/cnp-flux-config/commit/372bb2e7820bcdb091e69768dea13a5854003aa9

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
