### PR TITLE
fixes for Linux and first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ docker rm -f $(docker ps -a -q)
 docker system prune -a
 ```
 
+## Clean slate
+To reset your local env so it's totally clean, run the following:
+```bash
+./ccd compose down --volumes
+docker system prune -a
+docker rm -f $(docker ps -a -q)
+docker system prune -a
+```
+
 ## Quick start
 
 Checkout `ccd-docker` project:

--- a/bin/utils/ccd-add-role.sh
+++ b/bin/utils/ccd-add-role.sh
@@ -5,7 +5,6 @@ set -eu
 dir=$(dirname ${0})
 
 role=${1}
-
 userToken=$(${dir}/idam-lease-user-token.sh ${CCD_CONFIGURER_IMPORTER_USERNAME:-ccd.docker.default@hmcts.net} ${CCD_CONFIGURER_IMPORTER_PASSWORD:-Password12})
 totp=$(docker run --rm toolbelt/oathtool --totp -b ${CCD_API_GATEWAY_S2S_SECRET:-AAAAAAAAAAAAAAAC})
 serviceToken=$(${dir}/idam-lease-service-token.sh ccd_gw $totp)

--- a/bin/utils/idam-authenticate.sh
+++ b/bin/utils/idam-authenticate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 


### PR DESCRIPTION
### Change description ###
Added some notes on how to clean your install if you need to
Cleaned up the ad role code for readability and debugging
Fixed some shebangs which were not compatible on Ubuntu
Use the test-support endpoint for s2s as it's more reliable
Moved the .env file to be in same folder as the compose files so that Ubuntu picks it up (this should work on osx too)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
