### PR TITLE
Update keyword to match application.yaml

### DIFF
--- a/mocks/wiremock/mappings/fee-register/c2-with-notice.json
+++ b/mocks/wiremock/mappings/fee-register/c2-with-notice.json
@@ -16,7 +16,7 @@
         "equalTo": "family court"
       },
       "keyword": {
-        "equalTo": "notice"
+        "equalTo": "GAOnNotice"
       },
       "service": {
         "equalTo": "other"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A (found during DFPL-824)


### Change description ###
The C2 with notice keyword in wiremock is outdated causing issues (breaking the PBA payment page) locally when doing:
> upload additional applications > C2 > Application with notice > _continue the flow_


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
